### PR TITLE
クイックステータス機能の実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -4,12 +4,21 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Mood;
+use App\Models\Post;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class PostController extends Controller
 {
     public function index(Mood $mood)
     {
         return Inertia::render("Dashboard", ["moods" => $mood->get()]);
+    }
+    
+    public function store(Request $request, Post $post)
+    {
+        $input = $request->all();
+        $post->fill($input)->save();
+        return redirect("/dashboard");
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -3,8 +3,13 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Mood;
+use Inertia\Inertia;
 
 class PostController extends Controller
 {
-    //
+    public function index(Mood $mood)
+    {
+        return Inertia::render("Dashboard", ["moods" => $mood->get()]);
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -8,4 +8,10 @@ use Illuminate\Database\Eloquent\Model;
 class Post extends Model
 {
     use HasFactory;
+    
+    protected $fillable = [
+        "user_id",
+        "mood_id",
+        "comment"
+    ];
 }

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -33,7 +33,7 @@ export default function Authenticated({ auth, header, children }) {
                             </div>
                             
                             <div className="hidden space-x-8 px-2 sm:-my-px sm:ml-10 sm:flex">
-                                <NavLink href={route('dashboard')} active={route().current('dashboard')}>
+                                <NavLink href={route('diary')} active={route().current('diary')}>
                                     <div className="flex items-center gap-2">
                                         <svg width="2rem" height="2rem" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                             <path d="M7 8.5H12M7 12H15M7 18V20.3355C7 20.8684 7 21.1348 7.10923 21.2716C7.20422 21.3906 7.34827 21.4599 7.50054 21.4597C7.67563 21.4595 7.88367 21.2931 8.29976 20.9602L10.6852 19.0518C11.1725 18.662 11.4162 18.4671 11.6875 18.3285C11.9282 18.2055 12.1844 18.1156 12.4492 18.0613C12.7477 18 13.0597 18 13.6837 18H16.2C17.8802 18 18.7202 18 19.362 17.673C19.9265 17.3854 20.3854 16.9265 20.673 16.362C21 15.7202 21 14.8802 21 13.2V7.8C21 6.11984 21 5.27976 20.673 4.63803C20.3854 4.07354 19.9265 3.6146 19.362 3.32698C18.7202 3 17.8802 3 16.2 3H7.8C6.11984 3 5.27976 3 4.63803 3.32698C4.07354 3.6146 3.6146 4.07354 3.32698 4.63803C3 5.27976 3 6.11984 3 7.8V14C3 14.93 3 15.395 3.10222 15.7765C3.37962 16.8117 4.18827 17.6204 5.22354 17.8978C5.60504 18 6.07003 18 7 18Z" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -44,7 +44,7 @@ export default function Authenticated({ auth, header, children }) {
                             </div>
                             
                             <div className="hidden space-x-8 px-2 sm:-my-px sm:ml-10 sm:flex">
-                                <NavLink href={route('dashboard')} active={route().current('dashboard')}>
+                                <NavLink href={route('analysis')} active={route().current('analysis')}>
                                     <div className="flex items-center gap-2">
                                         <svg width="2rem" height="2rem" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                             <path d="M21 21H4.6C4.03995 21 3.75992 21 3.54601 20.891C3.35785 20.7951 3.20487 20.6422 3.10899 20.454C3 20.2401 3 19.9601 3 19.4V3M21 7L15.5657 12.4343C15.3677 12.6323 15.2687 12.7313 15.1545 12.7684C15.0541 12.8011 14.9459 12.8011 14.8455 12.7684C14.7313 12.7313 14.6323 12.6323 14.4343 12.4343L12.5657 10.5657C12.3677 10.3677 12.2687 10.2687 12.1545 10.2316C12.0541 10.1989 11.9459 10.1989 11.8455 10.2316C11.7313 10.2687 11.6323 10.3677 11.4343 10.5657L7 15M21 7H17M21 7V11" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -55,7 +55,7 @@ export default function Authenticated({ auth, header, children }) {
                             </div>
                             
                             <div className="hidden space-x-8 px-2 sm:-my-px sm:ml-10 sm:flex">
-                                <NavLink href={route('dashboard')} active={route().current('dashboard')}>
+                                <NavLink href={route('profile.edit')} active={route().current('profile.edit')}>
                                     <div className="flex items-center gap-2">
                                         <svg width="2rem" height="2rem" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                             <path d="M20 21C20 19.6044 20 18.9067 19.8278 18.3389C19.44 17.0605 18.4395 16.06 17.1611 15.6722C16.5933 15.5 15.8956 15.5 14.5 15.5H9.5C8.10444 15.5 7.40665 15.5 6.83886 15.6722C5.56045 16.06 4.56004 17.0605 4.17224 18.3389C4 18.9067 4 19.6044 4 21M16.5 7.5C16.5 9.98528 14.4853 12 12 12C9.51472 12 7.5 9.98528 7.5 7.5C7.5 5.01472 9.51472 3 12 3C14.4853 3 16.5 5.01472 16.5 7.5Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/resources/js/Pages/Analysis.jsx
+++ b/resources/js/Pages/Analysis.jsx
@@ -1,7 +1,7 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head } from '@inertiajs/react';
 
-export default function Dashboard(props) {
+export default function Analysis(props) {
     return (
         <AuthenticatedLayout
             auth={props.auth}

--- a/resources/js/Pages/Analysis.jsx
+++ b/resources/js/Pages/Analysis.jsx
@@ -6,14 +6,14 @@ export default function Dashboard(props) {
         <AuthenticatedLayout
             auth={props.auth}
             errors={props.errors}
-            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Dashboard</h2>}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Analysis</h2>}
         >
-            <Head title="ホーム" />
+            <Head title="Dashboard" />
 
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900">ホームです</div>
+                        <div className="p-6 text-gray-900">You're logged in!</div>
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -1,10 +1,19 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import QuickStatus from '@/Pages/QuickStatus/QuickStatus'
-import { Head } from '@inertiajs/react';
+import { Head, useForm } from '@inertiajs/react';
 
 export default function Dashboard(props) {
     const { moods } = props;
-    console.log(props);
+    
+    const {data, setData, post} = useForm({
+        user_id: props.auth.user.id,
+        mood_id: "",
+        comment: ""
+    })
+    
+    const handleSendPosts = () => {
+        post("/posts");
+    }
     
     return (
         <AuthenticatedLayout
@@ -24,19 +33,37 @@ export default function Dashboard(props) {
                             <p className="text-lg">今の気分をシェアしましょう</p>
                         </div>
                         <form
+                            onSubmit={handleSendPosts}
                         >
-                            <div
+                            <fieldset
+                                name="mood_id"
+                                onChange={(e) => setData("mood_id", e.target.value)}
                                 className="mx-auto py-6 w-[60%] grid items-center justify-center grid-cols-5 gap-2"
                             >
-                                { moods.map((mood) => (
-                                    <button
-                                        key={mood.id}
-                                        className="w-16"
-                                    >
-                                       <img src={mood.image_path} />
-                                    </button>
-                                )) }
-                            </div>
+                                    { moods.map((mood) => (
+                                        <div
+                                            key={mood.id}
+                                        >
+                                            <input
+                                                type="radio"
+                                                id={mood.id}
+                                                className="w-16"
+                                                name="mood_id"
+                                                value={mood.id}
+                                            />
+                                            <label
+                                                htmlFor={mood.id}
+                                            >
+                                                <img src={mood.image_path} />
+                                            </label>
+                                        </div>
+                                    )) }
+                            </fieldset>
+                            <button
+                                type="submit"
+                            >
+                                記録する
+                            </button>
                         </form>
                     </div>
                 </div>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -17,10 +17,17 @@ export default function Dashboard(props) {
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                        <div className="py-6 flex items-center justify-center gap-2">
+                            <svg width="4rem" height="2rem" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M15.5 11.5H14.5L13 14.5L11 8.5L9.5 11.5H8.5M11.9932 5.13581C9.9938 2.7984 6.65975 2.16964 4.15469 4.31001C1.64964 6.45038 1.29697 10.029 3.2642 12.5604C4.75009 14.4724 8.97129 18.311 10.948 20.0749C11.3114 20.3991 11.4931 20.5613 11.7058 20.6251C11.8905 20.6805 12.0958 20.6805 12.2805 20.6251C12.4932 20.5613 12.6749 20.3991 13.0383 20.0749C15.015 18.311 19.2362 14.4724 20.7221 12.5604C22.6893 10.029 22.3797 6.42787 19.8316 4.31001C17.2835 2.19216 13.9925 2.7984 11.9932 5.13581Z" stroke="#FF2D2D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                            </svg>
+                            <p className="text-lg">今の気分をシェアしましょう</p>
+                        </div>
                         <form
-                            className="grid gap-4"
                         >
-                            <div>
+                            <div
+                                className="mx-auto py-6 w-[60%] grid items-center justify-center grid-cols-5 gap-2"
+                            >
                                 { moods.map((mood) => (
                                     <button
                                         key={mood.id}
@@ -31,9 +38,6 @@ export default function Dashboard(props) {
                                 )) }
                             </div>
                         </form>
-                        
-                        
-                        <div className="p-6 text-gray-900">You're logged in!</div>
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -34,6 +34,7 @@ export default function Dashboard(props) {
                         </div>
                         <form
                             onSubmit={handleSendPosts}
+                            className="py-4 flex flex-col items-center"
                         >
                             <fieldset
                                 name="mood_id"
@@ -43,11 +44,12 @@ export default function Dashboard(props) {
                                     { moods.map((mood) => (
                                         <div
                                             key={mood.id}
+                                            className="flex flex-col items-center"
                                         >
                                             <input
                                                 type="radio"
                                                 id={mood.id}
-                                                className="w-16"
+                                                className="w-4 h-4"
                                                 name="mood_id"
                                                 value={mood.id}
                                             />
@@ -61,6 +63,7 @@ export default function Dashboard(props) {
                             </fieldset>
                             <button
                                 type="submit"
+                                className="p-2 flex justify-center rounded-lg bg-pi-blue text-white"
                             >
                                 記録する
                             </button>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -1,7 +1,11 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import QuickStatus from '@/Pages/QuickStatus/QuickStatus'
 import { Head } from '@inertiajs/react';
 
 export default function Dashboard(props) {
+    const { moods } = props;
+    console.log(props);
+    
     return (
         <AuthenticatedLayout
             auth={props.auth}
@@ -13,6 +17,22 @@ export default function Dashboard(props) {
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                        <form
+                            className="grid gap-4"
+                        >
+                            <div>
+                                { moods.map((mood) => (
+                                    <button
+                                        key={mood.id}
+                                        className="w-16"
+                                    >
+                                       <img src={mood.image_path} />
+                                    </button>
+                                )) }
+                            </div>
+                        </form>
+                        
+                        
                         <div className="p-6 text-gray-900">You're logged in!</div>
                     </div>
                 </div>

--- a/resources/js/Pages/Diary.jsx
+++ b/resources/js/Pages/Diary.jsx
@@ -1,7 +1,7 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head } from '@inertiajs/react';
 
-export default function Dashboard(props) {
+export default function Diary(props) {
     return (
         <AuthenticatedLayout
             auth={props.auth}

--- a/resources/js/Pages/Diary.jsx
+++ b/resources/js/Pages/Diary.jsx
@@ -1,0 +1,22 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+export default function Dashboard(props) {
+    return (
+        <AuthenticatedLayout
+            auth={props.auth}
+            errors={props.errors}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Diary</h2>}
+        >
+            <Head title="Dashboard" />
+
+            <div className="py-12">
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">You're logged in!</div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Home/Home.jsx
+++ b/resources/js/Pages/Home/Home.jsx
@@ -1,0 +1,22 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+export default function Dashboard(props) {
+    return (
+        <AuthenticatedLayout
+            auth={props.auth}
+            errors={props.errors}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Dashboard</h2>}
+        >
+            <Head title="ホーム" />
+
+            <div className="py-12">
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">ホームです</div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -16,7 +16,7 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
     const submit = (e) => {
         e.preventDefault();
 
-        patch(route('profile.update'));
+        patch("{{route('profile.update')}}");
     };
 
     return (

--- a/resources/js/Pages/QuickStatus/QuickStatus.jsx
+++ b/resources/js/Pages/QuickStatus/QuickStatus.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+export default function QuickStatus(props) {
+    const { moods } = props;
+    console.log(props);
+    
+    return (
+        <div>
+            <div>
+                <p>今の気分をシェアしましょう</p>
+            </div>
+            
+            <form
+                className="grid gap-4"
+            >
+                <div>
+                    { moods.map((mood) => (
+                        <button key={mood.id}>
+                           <p>{ mood.mood }</p>
+                        </button>
+                    )) }
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\PostController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -25,9 +26,10 @@ Route::get('/', function () {
     ]);
 });
 
-Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::middleware('auth')->group(function () {
+    Route::get('/dashboard', [PostController::class, "index"])->name('dashboard');
+    // Route::get("/posts", [PostController::class, "index"]);
+});
 
 Route::get('/diary', function () {
     return Inertia::render('Diary');

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,8 @@ Route::get('/', function () {
 
 Route::middleware('auth')->group(function () {
     Route::get('/dashboard', [PostController::class, "index"])->name('dashboard');
-    // Route::get("/posts", [PostController::class, "index"]);
+    
+    Route::post("/posts", [PostController::class, "store"]);
 });
 
 Route::get('/diary', function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,14 @@ Route::get('/dashboard', function () {
     return Inertia::render('Dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 
+Route::get('/diary', function () {
+    return Inertia::render('Diary');
+})->middleware(['auth', 'verified'])->name('diary');
+
+Route::get('/analysis', function () {
+    return Inertia::render('Analysis');
+})->middleware(['auth', 'verified'])->name('analysis');
+
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
# issue
- close #15 
- close #14 
- close #13

# PR説明
- クイックステータス機能の実装に先立ち、各基本メニューのルーティングを実装しました
- クイックステータス機能のフロントエンド、及びバックエンドを実装しました

# 行った対応
- 感情をラジオボタンで選択して、送信ボタンを押すと感情が記録されるようになります

# 動作確認方法
- `npm run build` でビルドし `php artisan serve --port=8080` で実行してください

# チェックして欲しいポイント
