### PR TITLE
[front, back] ステータス編集機能の実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Http\Requests\PostRequest;
 use App\Models\Mood;
 use App\Models\Post;
+use App\Models\Status;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -19,11 +20,12 @@ class PostController extends Controller
                 ]);
     }
     
-    public function edit(Mood $mood, Post $post)
+    public function edit(Mood $mood, Post $post, Status $status)
     {
         return Inertia::render("Post/Edit", [
                     "moods" => $mood->get(),
-                    "post" => $post->orderBy('created_at', 'desc')->first()
+                    "post" => $post->orderBy('created_at', 'desc')->first(),
+                    "statuses" => $status->get()
                 ]);
     }
     

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -31,7 +31,7 @@ class PostController extends Controller
     {
         $input = $request->all();
         $post->fill($input)->save();
-        return redirect("/posts/" . $post->id);
+        return redirect("/dashboard");
     }
     
     public function store(Request $request, Post $post)

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -33,7 +33,7 @@ class PostController extends Controller
     {
         $input = $request->all();
         $post->fill($input)->save();
-        // 別中間テーブルに同じuseFormから値を追加するか、それともuseFormを分けた方がいいのか..
+        $post->statuses()->attach($request->status);
         return redirect("/dashboard");
     }
     

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -33,6 +33,7 @@ class PostController extends Controller
     {
         $input = $request->all();
         $post->fill($input)->save();
+        // 別中間テーブルに同じuseFormから値を追加するか、それともuseFormを分けた方がいいのか..
         return redirect("/dashboard");
     }
     

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -24,9 +24,9 @@ export default function Dashboard(props) {
         <AuthenticatedLayout
             auth={props.auth}
             errors={props.errors}
-            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Dashboard</h2>}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">ホーム</h2>}
         >
-            <Head title="Dashboard" />
+            <Head title="ホーム" />
 
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
@@ -70,7 +70,7 @@ export default function Dashboard(props) {
                             </fieldset>
                             <button
                                 type="submit"
-                                className="p-2 flex justify-center rounded-lg bg-pi-blue text-white"
+                                className="w-1/2 p-2 flex justify-center rounded-sm bg-pi-blue text-white"
                             >
                                 記録する
                             </button>
@@ -78,25 +78,26 @@ export default function Dashboard(props) {
                     </div>
                     {/* ここまでクイックステータス */}
                     
-                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                       <h2>じぶんのきぶん</h2>
-                       <div className="flex gap-4">
+                    <div className="mt-4 bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                       <h2 className="p-4 text-lg font-bold">じぶんのきぶん</h2>
+                       <div className="p-4 flex items-center justify-between gap-4">
                            <p>{post.comment}</p>
-                           <img 
-                                src={currentMood.image_path}
-                                className="w-10 h-10"
-                            />
-                           { /* この${id}が正しく取得できているかを調べる */}
-                           <Link href={route("posts.edit", post.id)}>
-                                <svg width="2rem" height="2rem" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                    <path d="M12 20H21M3.00003 20H4.67457C5.16376 20 5.40835 20 5.63852 19.9447C5.84259 19.8957 6.03768 19.8149 6.21663 19.7053C6.41846 19.5816 6.59141 19.4086 6.93732 19.0627L19.5001 6.49998C20.3285 5.67156 20.3285 4.32841 19.5001 3.49998C18.6716 2.67156 17.3285 2.67156 16.5001 3.49998L3.93729 16.0627C3.59139 16.4086 3.41843 16.5816 3.29475 16.7834C3.18509 16.9624 3.10428 17.1574 3.05529 17.3615C3.00003 17.5917 3.00003 17.8363 3.00003 18.3255V20Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                </svg>
-                           </Link>
+                           <div className="flex items-center gap-2">
+                               <img 
+                                    src={moods.filter((mood) => mood.id == post.mood_id).image_path}
+                                    className="w-10 h-10"
+                                />
+                               <Link href={route("posts.edit", post.id)}>
+                                    <svg width="2rem" height="2rem" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M12 20H21M3.00003 20H4.67457C5.16376 20 5.40835 20 5.63852 19.9447C5.84259 19.8957 6.03768 19.8149 6.21663 19.7053C6.41846 19.5816 6.59141 19.4086 6.93732 19.0627L19.5001 6.49998C20.3285 5.67156 20.3285 4.32841 19.5001 3.49998C18.6716 2.67156 17.3285 2.67156 16.5001 3.49998L3.93729 16.0627C3.59139 16.4086 3.41843 16.5816 3.29475 16.7834C3.18509 16.9624 3.10428 17.1574 3.05529 17.3615C3.00003 17.5917 3.00003 17.8363 3.00003 18.3255V20Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                    </svg>
+                               </Link>
+                           </div>
                        </div>
                     </div>
                     
-                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                       <h2>ともだちのきぶん</h2>
+                    <div className="mt-4 bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                       <h2 className="p-4 text-lg font-bold">ともだちのきぶん</h2>
                     </div>
                     
                 </div>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -87,7 +87,7 @@ export default function Dashboard(props) {
                                 className="w-10 h-10"
                             />
                            { /* この${id}が正しく取得できているかを調べる */}
-                           <Link href={`/posts/{post.id}/edit`}>
+                           <Link href={route("posts.edit", post.id)}>
                                 <svg width="2rem" height="2rem" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                     <path d="M12 20H21M3.00003 20H4.67457C5.16376 20 5.40835 20 5.63852 19.9447C5.84259 19.8957 6.03768 19.8149 6.21663 19.7053C6.41846 19.5816 6.59141 19.4086 6.93732 19.0627L19.5001 6.49998C20.3285 5.67156 20.3285 4.32841 19.5001 3.49998C18.6716 2.67156 17.3285 2.67156 16.5001 3.49998L3.93729 16.0627C3.59139 16.4086 3.41843 16.5816 3.29475 16.7834C3.18509 16.9624 3.10428 17.1574 3.05529 17.3615C3.00003 17.5917 3.00003 17.8363 3.00003 18.3255V20Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 </svg>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -5,7 +5,7 @@ import { Head, Link, useForm } from '@inertiajs/react';
 
 export default function Dashboard(props) {
     const { moods, post } = props;
-    const [currentMood, setCurrentMood] = useState(moods.filter((mood) => mood.id == post.mood_id));
+    const currentMood = moods.filter((mood) => mood.id == post.mood_id);
     
     console.log(currentMood);
     
@@ -84,7 +84,7 @@ export default function Dashboard(props) {
                            <p>{post.comment}</p>
                            <div className="flex items-center gap-2">
                                <img 
-                                    src={moods.filter((mood) => mood.id == post.mood_id).image_path}
+                                    src={currentMood[0].image_path}
                                     className="w-10 h-10"
                                 />
                                <Link href={route("posts.edit", post.id)}>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import {useState} from "react";
+import { useState } from "react";
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import QuickStatus from '@/Pages/QuickStatus/QuickStatus'
 import { Head, Link, useForm } from '@inertiajs/react';

--- a/resources/js/Pages/Post/Edit.jsx
+++ b/resources/js/Pages/Post/Edit.jsx
@@ -20,9 +20,9 @@ export default function Edit(props) {
          <AuthenticatedLayout
             auth={props.auth}
             errors={props.errors}
-            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Dashboard</h2>}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">感情を編集する</h2>}
         >
-            <Head title="Dashboard" />
+            <Head title="感情を編集する" />
 
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
@@ -36,13 +36,11 @@ export default function Edit(props) {
                     
                     <form
                         onSubmit={handleSendPosts}
-                        
+                        className="mt-4 p-4 flex flex-col items-center bg-white overflow-hidden shadow-sm sm:rounded-lg"
                     >
-                        
-                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900">
+                        <h1 className="p-6 text-gray-900 text-lg font-bold">
                             感情を変更する
-                        </div>
+                        </h1>
                         
                         
                         <fieldset
@@ -70,60 +68,54 @@ export default function Edit(props) {
                                         </div>
                                     )) }
                             </fieldset>
-                            
-                        
-                    </div>
-                    
-                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900">
-                            ひとこと
-                        </div>
-                        <textarea
-                            name="comment"
-                            value={post.comment}
-                            onChange={(e) => setData("comment", e.target.value)}
-                        >
-                        </textarea>
-                    </div>
-                    
-                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900">
-                            感じた場面・状況・背景
-                        </div>
-                        
-                        <fieldset
-                                className="mx-auto py-6 w-[60%] grid items-center justify-center grid-cols-5 gap-2"
-                                name="status_id"
+    
+                            <h1 className="p-6 text-gray-900 text-lg font-bold">
+                                ひとこと
+                            </h1>
+                            <textarea
+                                className="w-1/2 flex items-center justify-center rounded-sm"
+                                name="comment"
+                                value={post.comment}
+                                onChange={(e) => setData("comment", e.target.value)}
                             >
-                                    { statuses.map((status) => (
-                                        <div
-                                            key={status.id}
-                                            className="flex flex-col items-center"
-                                        >
-                                            <input
-                                                type="checkbox"
-                                                id={status.id}
-                                                className="w-4 h-4"
-                                                name="status_id"
-                                                value={status.id}
-                                            />
-                                            <label
-                                                htmlFor={status.id}
+                            </textarea>
+                        
+                            <h1 className="p-6 text-gray-900 text-lg font-bold">
+                                感じた場面・状況・背景
+                            </h1>
+                            
+                            <fieldset
+                                    className="mx-auto py-6 w-[60%] grid items-center justify-center grid-cols-5 gap-2"
+                                    name="status_id"
+                                >
+                                        { statuses.map((status) => (
+                                            <div
+                                                key={status.id}
+                                                className="flex flex-col items-center"
                                             >
-                                                <img src={status.image_path} />
-                                                <span>{status.status}</span>
-                                            </label>
-                                        </div>
-                                    )) }
-                            </fieldset>
-                    </div>
-                    
-                    <button
-                        className="p-4 bg-pi-blue text-white"
-                        type="submit"
-                    >
-                        保存する
-                    </button>
+                                                <input
+                                                    type="checkbox"
+                                                    id={status.id}
+                                                    className="w-4 h-4"
+                                                    name="status_id"
+                                                    value={status.id}
+                                                />
+                                                <label
+                                                    htmlFor={status.id}
+                                                >
+                                                    <img src={status.image_path} />
+                                                    <span>{status.status}</span>
+                                                </label>
+                                            </div>
+                                        )) }
+                                </fieldset>
+                        
+                            <button
+                                className="w-1/2 p-2 flex items-center justify-center rounded-sm bg-pi-blue text-white"
+                                type="submit"
+                            >
+                                保存する
+                            </button>
                     </form>
                 </div>
             </div>

--- a/resources/js/Pages/Post/Edit.jsx
+++ b/resources/js/Pages/Post/Edit.jsx
@@ -3,7 +3,7 @@ import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head, Link, useForm } from '@inertiajs/react';
 
 export default function Edit(props) {
-    const {moods, post} = props;
+    const {moods, post, statuses} = props;
     
     const {data, setData, put} = useForm({
         user_id: props.auth.user.id,
@@ -91,34 +91,31 @@ export default function Edit(props) {
                             感じた場面・状況・背景
                         </div>
                         
-                        { /*
                         <fieldset
-                                name="mood_id"
-                                onChange={(e) => setData("mood_id", e.target.value)}
                                 className="mx-auto py-6 w-[60%] grid items-center justify-center grid-cols-5 gap-2"
+                                name="status_id"
                             >
-                                    { moods.map((mood) => (
+                                    { statuses.map((status) => (
                                         <div
-                                            key={mood.id}
+                                            key={status.id}
                                             className="flex flex-col items-center"
                                         >
                                             <input
-                                                type="radio"
-                                                id={mood.id}
+                                                type="checkbox"
+                                                id={status.id}
                                                 className="w-4 h-4"
-                                                name="mood_id"
-                                                value={mood.id}
-                                                checked={mood.id == post.mood_id}
+                                                name="status_id"
+                                                value={status.id}
                                             />
                                             <label
-                                                htmlFor={mood.id}
+                                                htmlFor={status.id}
                                             >
-                                                <img src={mood.image_path} />
+                                                <img src={status.image_path} />
+                                                <span>{status.status}</span>
                                             </label>
                                         </div>
                                     )) }
                             </fieldset>
-                            */}
                     </div>
                     
                     <button

--- a/resources/js/Pages/Post/Edit.jsx
+++ b/resources/js/Pages/Post/Edit.jsx
@@ -20,7 +20,7 @@ export default function Edit(props) {
          <AuthenticatedLayout
             auth={props.auth}
             errors={props.errors}
-            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Diary</h2>}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Dashboard</h2>}
         >
             <Head title="Dashboard" />
 

--- a/resources/js/Pages/Post/Edit.jsx
+++ b/resources/js/Pages/Post/Edit.jsx
@@ -13,7 +13,7 @@ export default function Edit(props) {
     
     const handleSendPosts = (e) => {
         e.preventDefault();
-        put(`/posts/${post.id}`);
+        put(route("posts.update", post.id));
     }
     
     return (
@@ -27,12 +27,17 @@ export default function Edit(props) {
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900">
-                            ひとつ前に戻る
-                        </div>
+                        <Link href={route("dashboard")}>
+                            <div className="p-6 text-gray-900">
+                                ひとつ前に戻る
+                            </div>
+                        </Link>
                     </div>
                     
-                    <form>
+                    <form
+                        onSubmit={handleSendPosts}
+                        
+                    >
                         
                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div className="p-6 text-gray-900">
@@ -74,7 +79,9 @@ export default function Edit(props) {
                             ひとこと
                         </div>
                         <textarea
+                            name="comment"
                             value={post.comment}
+                            onChange={(e) => setData("comment", e.target.value)}
                         >
                         </textarea>
                     </div>
@@ -83,8 +90,43 @@ export default function Edit(props) {
                         <div className="p-6 text-gray-900">
                             感じた場面・状況・背景
                         </div>
+                        
+                        { /*
+                        <fieldset
+                                name="mood_id"
+                                onChange={(e) => setData("mood_id", e.target.value)}
+                                className="mx-auto py-6 w-[60%] grid items-center justify-center grid-cols-5 gap-2"
+                            >
+                                    { moods.map((mood) => (
+                                        <div
+                                            key={mood.id}
+                                            className="flex flex-col items-center"
+                                        >
+                                            <input
+                                                type="radio"
+                                                id={mood.id}
+                                                className="w-4 h-4"
+                                                name="mood_id"
+                                                value={mood.id}
+                                                checked={mood.id == post.mood_id}
+                                            />
+                                            <label
+                                                htmlFor={mood.id}
+                                            >
+                                                <img src={mood.image_path} />
+                                            </label>
+                                        </div>
+                                    )) }
+                            </fieldset>
+                            */}
                     </div>
                     
+                    <button
+                        className="p-4 bg-pi-blue text-white"
+                        type="submit"
+                    >
+                        保存する
+                    </button>
                     </form>
                 </div>
             </div>

--- a/resources/js/Pages/Post/Edit.jsx
+++ b/resources/js/Pages/Post/Edit.jsx
@@ -8,7 +8,8 @@ export default function Edit(props) {
     const {data, setData, put} = useForm({
         user_id: props.auth.user.id,
         mood_id: post.mood_id,
-        comment: post.comment
+        comment: post.comment,
+        status: "hello"
     })
     
     const handleSendPosts = (e) => {
@@ -86,6 +87,7 @@ export default function Edit(props) {
                             
                             <fieldset
                                     className="mx-auto py-6 w-[60%] grid items-center justify-center grid-cols-5 gap-2"
+                                    onChange={(e) => setData("status", e.target.value)}
                                     name="status_id"
                                 >
                                         { statuses.map((status) => (

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/dashboard', [PostController::class, "index"])->name('dashboard');
     
     Route::get('/posts/{post}/edit', [PostController::class, 'edit'])->name('posts.edit');
-    Route::put('/posts/{post}', [PostController::class, 'update']);
+    Route::put('/posts/{post}', [PostController::class, 'update'])->name('posts.update');
     
     Route::post('/posts', [PostController::class, 'store']);
 });


### PR DESCRIPTION
# issue
- close #19 
- close #20 

# PR説明
- 最新のステータスを表示し、編集ボタンを押すとさらに詳しい情報が登録できるようにしました
- それに伴って大まかなUIも作成しました

# 行った対応

# 動作確認方法
- `npm run build`を行った後、`php artisan serve --port=8080` で立ち上げてください

# チェックして欲しいポイント
