### PR TITLE
[front] 感情グラフ機能のUI実装

### DIFF
--- a/app/Http/Controllers/ChartApiController.php
+++ b/app/Http/Controllers/ChartApiController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ChartApiController extends Controller
+{
+    // public function rader()
+    // {
+    //     return response()->json([
+    //         'labels' => ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+    //         'datasets' => [
+    //             [
+    //                 'label' => 'My First Dataset',
+    //                 'data' => [65, 59, 80, 81, 56, 55, 40],
+    //                 'fill' => false,
+    //                 'borderColor' => 'rgb(75, 192, 192)',
+    //                 'tension' => 0.1,
+    //             ],
+    //         ],
+    //     ]);
+    // }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,13 +4,17 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "chart.js": "^4.4.3",
+                "react-chartjs-2": "^5.2.0"
+            },
             "devDependencies": {
                 "@headlessui/react": "^1.4.2",
                 "@inertiajs/react": "^1.0.0",
                 "@tailwindcss/forms": "^0.5.3",
                 "@vitejs/plugin-react": "^3.0.0",
                 "autoprefixer": "^10.4.12",
-                "axios": "^1.1.2",
+                "axios": "^1.7.2",
                 "laravel-vite-plugin": "^0.7.2",
                 "lodash": "^4.17.19",
                 "postcss": "^8.4.18",
@@ -832,6 +836,11 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+            "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1028,9 +1037,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.6.8",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
             "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
@@ -1169,6 +1178,17 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/chart.js": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.3.tgz",
+            "integrity": "sha512-qK1gkGSRYcJzqrrzdR6a+I0vQ4/R+SoODXyAjscQ/4mzuNzySaMCd+hyVxitSY1+L2fjPD1Gbn+ibNqRmwQeLw==",
+            "dependencies": {
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=8"
             }
         },
         "node_modules/chokidar": {
@@ -1813,8 +1833,7 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/jsesc": {
             "version": "2.5.2",
@@ -1887,7 +1906,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             },
@@ -2354,12 +2372,20 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-chartjs-2": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+            "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
+            "peerDependencies": {
+                "chart.js": "^4.1.1",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "@tailwindcss/forms": "^0.5.3",
         "@vitejs/plugin-react": "^3.0.0",
         "autoprefixer": "^10.4.12",
-        "axios": "^1.1.2",
+        "axios": "^1.7.2",
         "laravel-vite-plugin": "^0.7.2",
         "lodash": "^4.17.19",
         "postcss": "^8.4.18",
@@ -18,5 +18,9 @@
         "react-dom": "^18.2.0",
         "tailwindcss": "^3.2.1",
         "vite": "^4.0.0"
+    },
+    "dependencies": {
+        "chart.js": "^4.4.3",
+        "react-chartjs-2": "^5.2.0"
     }
 }

--- a/resources/js/Pages/Analysis.jsx
+++ b/resources/js/Pages/Analysis.jsx
@@ -1,4 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import MoodRaderChart from '@/Pages/Analysis/MoodRaderChart';
 import { Head } from '@inertiajs/react';
 
 export default function Analysis(props) {
@@ -6,14 +7,18 @@ export default function Analysis(props) {
         <AuthenticatedLayout
             auth={props.auth}
             errors={props.errors}
-            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Analysis</h2>}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">感情グラフ</h2>}
         >
-            <Head title="Dashboard" />
+            <Head title="感情グラフ" />
 
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900">You're logged in!</div>
+                        
+                        <h1>ここ3日間の自分の気分</h1>
+                        
+                        <MoodRaderChart />
+                
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Analysis.jsx
+++ b/resources/js/Pages/Analysis.jsx
@@ -15,9 +15,11 @@ export default function Analysis(props) {
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         
-                        <h1>ここ3日間の自分の気分</h1>
+                        <h1 className="p-4 font-bold border-b border-gray-200">ここ3日間の自分の気分</h1>
                         
-                        <MoodRaderChart />
+                        <div className="w-2/3 h-2/3 mx-auto p-8">
+                            <MoodRaderChart />
+                        </div>
                 
                     </div>
                 </div>

--- a/resources/js/Pages/Analysis/MoodRaderChart.jsx
+++ b/resources/js/Pages/Analysis/MoodRaderChart.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+// import axios from 'axios';
 import {
   Chart as ChartJS,
   RadialLinearScale,
@@ -19,8 +20,17 @@ ChartJS.register(
   Legend
 );
 
+// const [chartData, setChartData] = useState(null);  // データ用の状態を初期化
+
+// useEffect(() => {
+//   axios.get('/api/chart-data')
+//     // .then(response => response.json())
+//     .then(data => setChartData(data))  // 取得したデータを状態に保存
+//     .catch(error => console.error('Error fetching data:', error));  // エラーハンドリング
+// }, []);
+
 export const data = {
-  labels: ['Thing 1', 'Thing 2', 'Thing 3', 'Thing 4', 'Thing 5', 'Thing 6'],
+  labels: ['Thing 1', 'Thing 2', 'Thing 3', 'Thing 4', 'Thing 5', 'Thing 6', 'Thing 7'],
   datasets: [
     {
       label: '# of Votes',
@@ -32,6 +42,10 @@ export const data = {
   ],
 };
 
+
 export default function MoodRaderChart() {
+  if (data == null) {
+      return <div>Loading...</div>;
+    }
   return <Radar data={data} />;
 }

--- a/resources/js/Pages/Analysis/MoodRaderChart.jsx
+++ b/resources/js/Pages/Analysis/MoodRaderChart.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Radar } from 'react-chartjs-2';
+
+ChartJS.register(
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend
+);
+
+export const data = {
+  labels: ['Thing 1', 'Thing 2', 'Thing 3', 'Thing 4', 'Thing 5', 'Thing 6'],
+  datasets: [
+    {
+      label: '# of Votes',
+      data: [2, 9, 3, 5, 2, 3],
+      backgroundColor: 'rgba(255, 99, 132, 0.2)',
+      borderColor: 'rgba(255, 99, 132, 1)',
+      borderWidth: 1,
+    },
+  ],
+};
+
+export default function MoodRaderChart() {
+  return <Radar data={data} />;
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\PostController;
+use App\Http\Controllers\ChartApiController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -46,6 +47,10 @@ Route::middleware('auth')->group(function () {
         return Inertia::render('Analysis');
     })->name('analysis');
 });
+
+// Route::middleware('auth')->group(function () {
+//     Route::get('/api/chart-data', [ChartApiController::class, 'rader']);
+// });
 
 
 Route::middleware('auth')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\PostController;
+use App\Http\Controllers\DiaryController;
 use App\Http\Controllers\ChartApiController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;


### PR DESCRIPTION
# issue
- close #33 

# PR説明
- 感情グラフの表示はできるようになりました
- データ取得処理はまだ未実装です

# 行った対応
- `npm i` を行ってパッケージをインストールしてください

# 動作確認方法
- `npm run build`の後に`php artisan serve --port=8080`で起動してください

# チェックして欲しいポイント
