### PR TITLE
[front] プロフィール編集UIの実装

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -43,11 +43,14 @@ class ProfileController extends Controller
         // }
         
         if ($request->has('image_path')) {
-            $image = $request->files->get('file');
+            // $image = $request->files->get('file');
             // $file_path = $image->getRealPath();
             // $cloudinary = new Cloudinary();
             // $image_url = $cloudinary->uploadApi()->upload($file_path)->getSecurePath();
-            $image_url = Cloudinary::upload($image->getRealPath())->getSecurePath();
+            
+            // $image_url = Cloudinary::upload($request->file('image_path')->getRealPath())->getSecurePath();
+            $image_url = Cloudinary::upload($request->file($request['image_path'])->getRealPath())->getSecurePath();
+            
             // $image = $request->file('image_path');
             // $upload_api = new UploadApi();
             // $image_url = $upload_api->upload($request['image_path']);

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -42,22 +42,22 @@ class ProfileController extends Controller
         //     $request->user()->image_path = $image_url;
         // }
         
-        if ($request->has('image_path')) {
+        // if ($request->has('image_path')) {
             // $image = $request->files->get('file');
             // $file_path = $image->getRealPath();
             // $cloudinary = new Cloudinary();
             // $image_url = $cloudinary->uploadApi()->upload($file_path)->getSecurePath();
             
             // $image_url = Cloudinary::upload($request->file('image_path')->getRealPath())->getSecurePath();
-            $image_url = Cloudinary::upload($request->file($request['image_path'])->getRealPath())->getSecurePath();
+            // $image_url = Cloudinary::upload($request->file($request['image_path'])->getRealPath())->getSecurePath();
             
             // $image = $request->file('image_path');
             // $upload_api = new UploadApi();
             // $image_url = $upload_api->upload($request['image_path']);
             // $image_url = Cloudinary\Uploader::upload($image->getPathname())['secure_url'];
-            dd($image_url);
-            $request->user()->image_path = $image_url;
-        }
+            // dd($image_url);
+        //     $request->user()->image_path = $image_url;
+        // }
 
         if ($request->user()->isDirty('email')) {
             $request->user()->email_verified_at = null;

--- a/resources/js/Pages/Profile/Edit.jsx
+++ b/resources/js/Pages/Profile/Edit.jsx
@@ -8,9 +8,9 @@ export default function Edit({ auth, mustVerifyEmail, status }) {
     return (
         <AuthenticatedLayout
             auth={auth}
-            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Profile</h2>}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">プロフィール編集</h2>}
         >
-            <Head title="Profile" />
+            <Head title="プロフィール編集" />
 
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">

--- a/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx
+++ b/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx
@@ -46,25 +46,23 @@ export default function DeleteUserForm({ className }) {
     return (
         <section className={`space-y-6 ${className}`}>
             <header>
-                <h2 className="text-lg font-medium text-gray-900">Delete Account</h2>
+                <h2 className="text-lg font-medium text-gray-900">アカウントを削除する</h2>
 
                 <p className="mt-1 text-sm text-gray-600">
-                    Once your account is deleted, all of its resources and data will be permanently deleted. Before
-                    deleting your account, please download any data or information that you wish to retain.
+                    一旦アカウントを削除すると、データを復元することができません。アカウントを削除する前によく確認してください。
                 </p>
             </header>
 
-            <DangerButton onClick={confirmUserDeletion}>Delete Account</DangerButton>
+            <DangerButton onClick={confirmUserDeletion}>アカウントを削除する</DangerButton>
 
             <Modal show={confirmingUserDeletion} onClose={closeModal}>
                 <form onSubmit={deleteUser} className="p-6">
                     <h2 className="text-lg font-medium text-gray-900">
-                        Are you sure you want to delete your account?
+                        本当に削除しますか？
                     </h2>
 
                     <p className="mt-1 text-sm text-gray-600">
-                        Once your account is deleted, all of its resources and data will be permanently deleted. Please
-                        enter your password to confirm you would like to permanently delete your account.
+                        削除する場合は現在のアカウントのパスワードを入力してください。
                     </p>
 
                     <div className="mt-6">
@@ -86,10 +84,10 @@ export default function DeleteUserForm({ className }) {
                     </div>
 
                     <div className="mt-6 flex justify-end">
-                        <SecondaryButton onClick={closeModal}>Cancel</SecondaryButton>
+                        <SecondaryButton onClick={closeModal}>キャンセルする</SecondaryButton>
 
                         <DangerButton className="ml-3" disabled={processing}>
-                            Delete Account
+                            アカウントを削除する
                         </DangerButton>
                     </div>
                 </form>

--- a/resources/js/Pages/Profile/Partials/UpdatePasswordForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdatePasswordForm.jsx
@@ -39,16 +39,16 @@ export default function UpdatePasswordForm({ className }) {
     return (
         <section className={className}>
             <header>
-                <h2 className="text-lg font-medium text-gray-900">Update Password</h2>
+                <h2 className="text-lg font-medium text-gray-900">パスワードの更新</h2>
 
                 <p className="mt-1 text-sm text-gray-600">
-                    Ensure your account is using a long, random password to stay secure.
+                    セキュリティのためパスワードを更新してください。
                 </p>
             </header>
 
             <form onSubmit={updatePassword} className="mt-6 space-y-6">
                 <div>
-                    <InputLabel htmlFor="current_password" value="Current Password" />
+                    <InputLabel htmlFor="current_password" value="現在のパスワード" />
 
                     <TextInput
                         id="current_password"
@@ -64,7 +64,7 @@ export default function UpdatePasswordForm({ className }) {
                 </div>
 
                 <div>
-                    <InputLabel htmlFor="password" value="New Password" />
+                    <InputLabel htmlFor="password" value="新しいパスワード" />
 
                     <TextInput
                         id="password"
@@ -80,7 +80,7 @@ export default function UpdatePasswordForm({ className }) {
                 </div>
 
                 <div>
-                    <InputLabel htmlFor="password_confirmation" value="Confirm Password" />
+                    <InputLabel htmlFor="password_confirmation" value="新しいパスワード（再入力）" />
 
                     <TextInput
                         id="password_confirmation"
@@ -95,7 +95,7 @@ export default function UpdatePasswordForm({ className }) {
                 </div>
 
                 <div className="flex items-center gap-4">
-                    <PrimaryButton disabled={processing}>Save</PrimaryButton>
+                    <PrimaryButton disabled={processing}>保存する</PrimaryButton>
 
                     <Transition
                         show={recentlySuccessful}
@@ -103,7 +103,7 @@ export default function UpdatePasswordForm({ className }) {
                         leaveTo="opacity-0"
                         className="transition ease-in-out"
                     >
-                        <p className="text-sm text-gray-600">Saved.</p>
+                        <p className="text-sm text-gray-600">保存しました。</p>
                     </Transition>
                 </div>
             </form>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -8,7 +8,7 @@ import { Transition } from '@headlessui/react';
 
 export default function UpdateProfileInformation({ mustVerifyEmail, status, className }) {
     const user = usePage().props.auth.user;
-    const [image, setImage] = useState(null);
+    const [image, setImage] = useState("");
 
     const { data, setData, patch, errors, processing, recentlySuccessful } = useForm({
         name: user.name,
@@ -22,12 +22,16 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
     };
     
     const handleImage = (e) => {
-        setImage(e.target.files[e.target.files.length - 1]);
+        setImage(e.target.files[e.target.files.length]);
     }
     
-    const getImagePath = (image) => {
-        const file = image;
-        return file.prototype.webkitRelativePath;
+    const getImagePath = (image, e) => {
+        const reader = new FileReader();
+        const blobs = new blob(e.target.files);
+        const blob = reader.readAsArrayBuffer(blobs);
+        const result = reader.readAsDataURL(blob[e.target.files.length]);
+        console.log(result);
+        return result;
     } 
 
     return (

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -25,28 +25,27 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
         setImage(e.target.files[e.target.files.length]);
     }
     
-    const getImagePath = (image, e) => {
+    const getImagePath = (image) => {
         const reader = new FileReader();
-        const blobs = new blob(e.target.files);
-        const blob = reader.readAsArrayBuffer(blobs);
-        const result = reader.readAsDataURL(blob[e.target.files.length]);
-        console.log(result);
-        return result;
+        const blob = reader.readAsArrayBuffer(image);
+        const result = reader.readAsDataURL(blob);
+        // console.log(result);
+        return reader.result;
     } 
 
     return (
         <section className={className}>
             <header>
-                <h2 className="text-lg font-medium text-gray-900">Profile Information</h2>
+                <h2 className="text-lg font-medium text-gray-900">プロフィール情報編集</h2>
 
                 <p className="mt-1 text-sm text-gray-600">
-                    Update your account's profile information and email address.
+                    登録しているプロフィール情報を変更できます。
                 </p>
             </header>
 
             <form onSubmit={submit} className="mt-6 space-y-6" enctype="multipart/form-data">
                 <div>
-                    <InputLabel htmlFor="image_path" value="Image" />
+                    <InputLabel htmlFor="image_path" value="プロフィール画像" />
                     
                     <input
                         type="file"
@@ -61,7 +60,7 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
                 </div>
                 
                 <div>
-                    <InputLabel htmlFor="name" value="Name" />
+                    <InputLabel htmlFor="name" value="表示名" />
 
                     <TextInput
                         id="name"
@@ -77,7 +76,7 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
                 </div>
 
                 <div>
-                    <InputLabel htmlFor="email" value="Email" />
+                    <InputLabel htmlFor="email" value="Eメールアドレス" />
 
                     <TextInput
                         id="email"
@@ -95,27 +94,27 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
                 {mustVerifyEmail && user.email_verified_at === null && (
                     <div>
                         <p className="text-sm mt-2 text-gray-800">
-                            Your email address is unverified.
+                            まだEメールアドレスの認証が終わっていません。
                             <Link
                                 href={route('verification.send')}
                                 method="post"
                                 as="button"
                                 className="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                             >
-                                Click here to re-send the verification email.
+                                このリンクをクリックしてメールアドレスを認証してください。
                             </Link>
                         </p>
 
                         {status === 'verification-link-sent' && (
                             <div className="mt-2 font-medium text-sm text-green-600">
-                                A new verification link has been sent to your email address.
+                                登録したアドレスに認証メールを送信しました。
                             </div>
                         )}
                     </div>
                 )}
 
                 <div className="flex items-center gap-4">
-                    <PrimaryButton disabled={processing}>Save</PrimaryButton>
+                    <PrimaryButton disabled={processing}>保存する</PrimaryButton>
 
                     <Transition
                         show={recentlySuccessful}
@@ -123,7 +122,7 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
                         leaveTo="opacity-0"
                         className="transition ease-in-out"
                     >
-                        <p className="text-sm text-gray-600">Saved.</p>
+                        <p className="text-sm text-gray-600">保存しました。</p>
                     </Transition>
                 </div>
             </form>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -1,3 +1,4 @@
+import React, {useState} from "react";
 import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import PrimaryButton from '@/Components/PrimaryButton';
@@ -7,6 +8,7 @@ import { Transition } from '@headlessui/react';
 
 export default function UpdateProfileInformation({ mustVerifyEmail, status, className }) {
     const user = usePage().props.auth.user;
+    const [image, setImage] = useState(null);
 
     const { data, setData, patch, errors, processing, recentlySuccessful } = useForm({
         name: user.name,
@@ -16,9 +18,17 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
 
     const submit = (e) => {
         e.preventDefault();
-
-        patch("{{route('profile.update')}}");
+        patch(route("profile.update"));
     };
+    
+    const handleImage = (e) => {
+        setImage(e.target.files[e.target.files.length - 1]);
+    }
+    
+    const getImagePath = (image) => {
+        const file = image;
+        return file.prototype.webkitRelativePath;
+    } 
 
     return (
         <section className={className}>
@@ -40,7 +50,7 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
                         className="mt-1 block w-full"
                         name="image_path"
                         value={data.image_path}
-                        onChange={(e) => setData('image_path', e.target.value)}
+                        onChange={(e) => {handleImage; getImagePath(image); setData('image_path', image)}}
                         />
                     
                     <InputError className="mt-2" message={errors.image_path} />

--- a/resources/js/Pages/Welcome.jsx
+++ b/resources/js/Pages/Welcome.jsx
@@ -5,7 +5,7 @@ export default function Welcome(props) {
     return (
         <>
             <Head title="Welcome" />
-            <div className="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 dark:bg-dots-lighter dark:bg-gray-900 selection:bg-red-500 selection:text-white">
+            <div className="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 selection:bg-red-500 selection:text-white">
                 <div className="sm:fixed sm:top-0 sm:right-0 p-6 text-right">
                     {props.auth.user ? (
                         <Link


### PR DESCRIPTION
# issue
- close #6

# PR説明
- プロフィール編集ページのUIを日本語に直しました
- プロフィール画像設定はファイルの絶対パスが取得できていないため実装が難しいです

# 行った対応

# 動作確認方法
- `npm run build` を行い `php artisan serve --port=8080` で立ち上げてください

# チェックして欲しいポイント
